### PR TITLE
Update version and adding python 3 support

### DIFF
--- a/tensorflow-notebook/values.yaml
+++ b/tensorflow-notebook/values.yaml
@@ -4,7 +4,7 @@
 jupyter:
   image:
     repository: tensorflow/tensorflow
-    tag: 1.6.0-devel
+    tag: 1.12.0-devel-py3
     pullPolicy: Always
   password: okteto
   resources:
@@ -14,7 +14,7 @@ jupyter:
 tensorboard:
   image:
     repository: tensorflow/tensorflow
-    tag: 1.6.0-devel
+    tag: 1.12.0-devel-py3
     pullPolicy: Always
 service:
   type: ClusterIP


### PR DESCRIPTION
I am adding the tag with the highest version that can run on Okteto Cloud (based on current tests) with Python 3 Support Because python 2 support has been ended.