### PR TITLE
Update OpenFaaS Chart to latest Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /public
+
+# Jet brains based IDEs
+.idea

--- a/openfaas/Chart.yaml
+++ b/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.4.0
+version: 5.7.2
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/openfaas/templates/crd.yaml
+++ b/openfaas/templates/crd.yaml
@@ -7,8 +7,11 @@ metadata:
   name: functions.openfaas.com
 spec:
   group: openfaas.com
-  version: v1alpha2
+  version: v1
   versions:
+    - name: v1
+      served: true
+      storage: true
     - name: v1alpha2
       served: true
       storage: true
@@ -32,6 +35,20 @@ spec:
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
             image:
               type: string
+            annotations:
+              anyOf:
+                - type: string
+                - type: object
+            labels:
+              anyOf:
+                - type: string
+                - type: object
+            constraints:
+              type: array
+            secrets:
+              type: array
+            readOnlyRootFilesystem:
+              type: boolean
             limits:
               properties:
                 cpu:

--- a/openfaas/templates/gateway-dep.yaml
+++ b/openfaas/templates/gateway-dep.yaml
@@ -80,6 +80,10 @@ spec:
           {{- end }}
           timeoutSeconds: 5
         env:
+        {{- if .Values.gateway.logsProviderURL }}
+        - name: logs_provider_url
+          value: "{{ .Values.gateway.logsProviderURL }}"
+        {{- end }}
         - name: read_timeout
           value: "{{ .Values.gateway.readTimeout }}"
         - name: write_timeout
@@ -122,10 +126,17 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: "/var/secrets"
+        {{- if .Values.oauth2Plugin.enabled }}
+        - name: auth_proxy_url
+          value: "http://oauth2-plugin.{{ .Release.Namespace }}:8080/validate"
+        - name: auth_pass_body
+          value: "false"
+        {{- else }}
         - name: auth_proxy_url
           value: "http://basic-auth-plugin.{{ .Release.Namespace }}:8080/validate"
         - name: auth_pass_body
           value: "false"
+        {{- end }}
         {{- end }}
         - name: scale_from_zero
           value: "{{ .Values.gateway.scaleFromZero }}"
@@ -150,9 +161,8 @@ spec:
         image: {{ .Values.operator.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
-          - ./openfaas-operator
-          - -logtostderr
-          - -v=2
+          - ./faas-netes
+          - -operator=true
         env:
           - name: port
             value: "8081"

--- a/openfaas/templates/ingress-operator-rbac.yaml
+++ b/openfaas/templates/ingress-operator-rbac.yaml
@@ -29,7 +29,7 @@ rules:
 - apiGroups: ["openfaas.com"]
   resources: ["functioningresses"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]

--- a/openfaas/values.yaml
+++ b/openfaas/values.yaml
@@ -22,7 +22,7 @@ gatewayExternal:
   annotations: {}
 
 gateway:
-  image: openfaas/gateway:0.18.7
+  image: openfaas/gateway:0.18.17
   readTimeout : "65s"
   writeTimeout : "65s"
   upstreamTimeout : "60s"  # Must be smaller than read/write_timeout
@@ -33,13 +33,47 @@ gateway:
   maxIdleConns: 1024
   maxIdleConnsPerHost: 1024
   directFunctions: true
+  # Custom logs provider url. For example openfaas-loki would be
+  # "http://ofloki-openfaas-loki.openfaas:9191/"
+  logsProviderURL: ""
   resources:
     requests:
       memory: "120Mi"
       cpu: "50m"
 
+basicAuthPlugin:
+  image: openfaas/basic-auth-plugin:0.18.11
+  replicas: 1
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "20m"
+
+oauth2Plugin:
+  enabled: false
+  provider: "" # Leave blank, or put "azure"
+  license: "example"
+  insecureTLS: false
+  scopes: "openid profile email"
+  jwksURL: https://example.eu.auth0.com/.well-known/jwks.json
+  tokenURL: https://example.eu.auth0.com/oauth/token
+  audience: https://example.eu.auth0.com/api/v2/
+  authorizeURL: https://example.eu.auth0.com/authorize
+  welcomePageURL: https://gw.oauth.example.com
+  cookieDomain: ".oauth.example.com"
+  baseHost: "http://auth.oauth.example.com"
+  clientSecret: SECRET
+  clientID: ID
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+  replicas: 1
+  image: openfaas/openfaas-oidc-plugin:0.3.3
+  securityContext: true
+
 faasnetes:
-  image: openfaas/faas-netes:0.9.15
+  image: openfaas/faas-netes:0.10.3
   readTimeout : "60s"
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
@@ -60,7 +94,7 @@ faasnetes:
 
 # replaces faas-netes with openfaas-operator
 operator:
-  image: openfaas/openfaas-operator:0.12.0
+  image: openfaas/faas-netes:0.10.3
   create: false
   # set this to false when creating multiple releases in the same cluster
   # must be true for the first one only
@@ -73,7 +107,7 @@ operator:
 queueWorker:
   durableQueueSubscription: false
   queueGroup: "faas"
-  image: openfaas/queue-worker:0.9.0
+  image: openfaas/queue-worker:0.10.1
   ackWait : "60s"
   replicas: 1
   gatewayInvoke: true
@@ -108,7 +142,7 @@ nats:
     enabled: false
     host: ""
     port: ""
-  image: nats-streaming:0.11.2
+  image: nats-streaming:0.17.0
   enableMonitoring: false
   resources:
     requests:
@@ -131,7 +165,7 @@ ingress:
 # ingressOperator (optional) – component to have specific FQDN and TLS for Functions
 # https://github.com/openfaas-incubator/ingress-operator
 ingressOperator:
-  image: openfaas/ingress-operator:0.4.0
+  image: openfaas/ingress-operator:0.5.0
   replicas: 1
   create: false
   resources:
@@ -140,7 +174,7 @@ ingressOperator:
 
 # faas-idler configuration
 faasIdler:
-  image: openfaas/faas-idler:0.2.1
+  image: openfaas/faas-idler:0.3.0
   replicas: 1
   create: true
   inactivityDuration: 15m               # If a function is inactive for 15 minutes, it may be scaled to zero


### PR DESCRIPTION
Updated OpenFaaS Chart for v 5.7.4 chart 

This has been tested by following steps provided by @rberrelleza (Thanks!!)


Deployed from my own private chare registry into my Okteto namespace. Deplyed a function and checked the external domain name created (https://gateway-external-waterdrips.cloud.okteto.net) 

Function invoked and a response was received.

This is minimal version upgrades inline with the OpenFaaS chart.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>