### PR TITLE
add username and password to terminal notes

### DIFF
--- a/terminal/templates/NOTES.txt
+++ b/terminal/templates/NOTES.txt
@@ -1,4 +1,8 @@
 To access your terminal, click on the URL displayed in the Okteto Cloud UI, and type your username and password.
 
-The terminal is already configured with okteto, kubectl and helm, and runs with namespace-wide permissions.
+{{- if .Values.credentials }}
+Username: "{{ (split ":" .Values.credentials)._0 }}"  
+Password: "{{ (split ":" .Values.credentials)._1 }}"
+{{- end }}
 
+The terminal is already configured with okteto, kubectl and helm, and runs with namespace-wide permissions.

--- a/terminal/templates/NOTES.txt
+++ b/terminal/templates/NOTES.txt
@@ -1,6 +1,7 @@
 To access your terminal, click on the URL displayed in the Okteto Cloud UI, and type your username and password.
 
 {{- if .Values.credentials }}
+
 Username: "{{ (split ":" .Values.credentials)._0 }}"  
 Password: "{{ (split ":" .Values.credentials)._1 }}"
 {{- end }}


### PR DESCRIPTION
Few users have reached out. Until we have private endpoints and automatic auth, this might help reduce the user's confusion.