### PR TITLE
Adding port option for Theia template

### DIFF
--- a/theia/templates/deployment.yaml
+++ b/theia/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           command: 
           - sh 
           - -c
-          - ([[ ! -z "$GIT_TOKEN" ]] && (cp /var/okteto/helper/creds $HOME/.creds && chmod +x $HOME/.creds && git config --global credential.helper $HOME/.creds));{{ if .Values.repository }}(test -d /home/project/.git || git clone {{ .Values.repository }} /home/project);{{ end }}PATH=$PATH:/var/okteto/bin node $HOME/src-gen/backend/main.js /home/project --hostname=0.0.0.0
+          - ([[ ! -z "$GIT_TOKEN" ]] && (cp /var/okteto/helper/creds $HOME/.creds && chmod +x $HOME/.creds && git config --global credential.helper $HOME/.creds));{{ if .Values.repository }}(test -d /home/project/.git || git clone {{ .Values.repository }} /home/project);{{ end }}PATH=$PATH:/var/okteto/bin node $HOME/src-gen/backend/main.js /home/project --hostname=0.0.0.0{{ if .Values.service.port }} --port {{ .Values.service.port }}{{ end }}
           env:
             - name: THEIA_PLUGINS
               value: /home/plugins

--- a/theia/values-okteto.yaml
+++ b/theia/values-okteto.yaml
@@ -1,6 +1,10 @@
 # available runtimes: go, python, dart, cpp, java, rust, nodejs
 runtime: nodejs
 
+# This is the port that Theia is running on. Change this if you want to use this port instead
+service:
+  port: 3000 # Default Theia port
+  
 # use this to clone a public repository automatically
 repository: https://github.com/okteto/movies
 

--- a/theia/values-okteto.yaml
+++ b/theia/values-okteto.yaml
@@ -1,12 +1,12 @@
 # available runtimes: go, python, dart, cpp, java, rust, nodejs
 runtime: nodejs
 
+# use this to clone a public repository automatically
+repository: https://github.com/okteto/movies
+
 # This is the port that Theia is running on. Change this if you want to use this port instead
 service:
   port: 3000 # Default Theia port
-  
-# use this to clone a public repository automatically
-repository: https://github.com/okteto/movies
 
 # set this when using a private repository https://github.com/settings/tokens
 # or add a GIT_TOKEN okteto secret


### PR DESCRIPTION
Hey, I tested out the Theia chart from the pre-built templates and my application wants to access port 3000 and that didn't quite work out. Checked quickly and there's a theia cli flag to specify the port so this PR adds that to it.

I also added it to the values-okteto.yaml to make it clear for users why their application may not be running