### PR TITLE
Keep previous chart versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM okteto/okteto:1.8.4 as build
 WORKDIR /usr/src/app
-RUN apk add --no-cache make
+RUN apk add --no-cache make curl
 RUN wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64" && chmod +x /usr/local/bin/yq
 
 # the public URL of the repo e.g. https://charts-rberrelleza.cloud.okteto.net

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ $(DIRS):
 	cp $@/*.png public/$@
 
 index:
-	helm repo index --url $(URL) public
+	curl $(URL)/index.yaml -o public/index.yaml
+	helm repo index --merge public/index.yaml --url $(URL) public
 	
 publish:
 	gsutil -m -h "Cache-Control:public, max-age=60" rsync -r public gs://apps.okteto.com


### PR DESCRIPTION
Keep the chart previous versions by merging the new repository index with the current one