### PR TITLE
respect ingress.enabled: false in terminal

### DIFF
--- a/terminal/templates/ingress.yaml
+++ b/terminal/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ingress.enabled }}
 {{- $fullName := include "terminal.fullname" . -}}
 {{- $svcPort := .Values.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -35,3 +36,4 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
If you are not running on okteto cloud and you install the terminal chart, currently you get an unprotected ingress

This is true even if you set ingress.enabled: false

This commit fixes that!