### PR TITLE
Upgrade golang to 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: okteto/golang-ci:1.18
+      - image: okteto/golang-ci:1.18.0
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
             - public
   publish:
       docker:
-          - image:  okteto/golang-ci:1.18
+          - image:  okteto/golang-ci:1.18.0
       steps:
         - checkout
         - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: okteto/golang-ci:1.17.4
+      - image: okteto/golang-ci:1.18
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
             - public
   publish:
       docker:
-          - image:  okteto/golang-ci:1.17.4
+          - image:  okteto/golang-ci:1.18
       steps:
         - checkout
         - attach_workspace:


### PR DESCRIPTION
We're currently using `go 1.17` which was released a year ago and is [no longer supported](https://endoflife.date/go)
`1.18` was released 5 months ago and is battle tested, in contrast to `1.19` which was released a week ago.

This PR upgrades to `1.18` and is related to https://github.com/okteto/okteto/pull/3016.